### PR TITLE
Upgrade to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 MAINTAINER david@logicalspark.com
 
-ENV TIKA_VERSION 1.19
+ENV TIKA_VERSION 1.19.1
 ENV TIKA_SERVER_URL https://www.apache.org/dist/tika/tika-server-$TIKA_VERSION.jar
 
 RUN	apt-get update \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # docker-tikaserver
-This repo contains the Dockerfile to create a docker image that contains the latest Ubuntu running the Apache Tika 1.19 Server on Port 9998 using Java 8.
+This repo contains the Dockerfile to create a docker image that contains the latest Ubuntu running the Apache Tika 1.19.1 Server on Port 9998 using Java 8.
 
 Out-of-the-box the container also includes dependencies for the GDAL and Tesseract OCR parsers.  To balance showing functionality versus the size of the image, this file currently installs the language packs for the following languages:
 * English


### PR DESCRIPTION
Hi,

Tika 1.19 is concerned by a security issue: CVE-2018-11796

This PR is a proposal to upgrade current image to 1.19.1 which fixes this security issue.

I hope regenerating the image could also fix: https://github.com/LogicalSpark/docker-tikaserver/issues/11

Regards,
Raphaël Ouazana.