### PR TITLE
Upgrade JDK version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV TIKA_VERSION 1.21
 ENV TIKA_SERVER_URL https://www.apache.org/dist/tika/tika-server-$TIKA_VERSION.jar
 
 RUN	apt-get update \
-	&& apt-get install gnupg openjdk-8-jre-headless curl gdal-bin tesseract-ocr \
+	&& apt-get install gnupg openjdk-11-jre-headless curl gdal-bin tesseract-ocr \
 		tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu -y \
 	&& curl -sSL https://people.apache.org/keys/group/tika.asc -o /tmp/tika.asc \
 	&& gpg --import /tmp/tika.asc \


### PR DESCRIPTION
Pre Java 10 does not properly handle JVM memory in a container by default, more info here: https://www.javaadvent.com/2018/12/docker-and-the-jvm.html