### PR TITLE
Improve `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM runtime_deps as fetch_tika
 
 ARG TIKA_VERSION
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg curl jq \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 curl jq \
     && curl -sSL https://www.apache.org/dist/tika/KEYS | gpg --import \
     && curl -sSL https://www.apache.org/dist/tika/tika-server-${TIKA_VERSION}.jar.asc -o /tika-server-${TIKA_VERSION}.jar.asc \
     && NEAREST_TIKA_SERVER_URL=$(curl --fail -sSL https://www.apache.org/dyn/closer.cgi/tika/tika-server-${TIKA_VERSION}.jar?asjson=1 | jq --raw-output '.preferred + .path_info') \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,42 @@
-FROM ubuntu:latest
-MAINTAINER david@logicalspark.com
+ARG TIKA_VERSION=1.23
 
-ENV TIKA_VERSION 1.23
-ENV TIKA_SERVER_URL https://www.apache.org/dist/tika/tika-server-$TIKA_VERSION.jar
+FROM ubuntu:latest as apt_base
 
-RUN	apt-get update \
-	&& apt-get install gnupg openjdk-11-jre-headless curl gdal-bin tesseract-ocr \
-		tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu -y \
-	&& curl -sSL https://people.apache.org/keys/group/tika.asc -o /tmp/tika.asc \
-	&& gpg --import /tmp/tika.asc \
-	&& curl -sSL "$TIKA_SERVER_URL.asc" -o /tmp/tika-server-${TIKA_VERSION}.jar.asc \
-	&& NEAREST_TIKA_SERVER_URL=$(curl -sSL http://www.apache.org/dyn/closer.cgi/${TIKA_SERVER_URL#https://www.apache.org/dist/}\?asjson\=1 \
-		| awk '/"path_info": / { pi=$2; }; /"preferred":/ { pref=$2; }; END { print pref " " pi; };' \
-		| sed -r -e 's/^"//; s/",$//; s/" "//') \
-	&& echo "Nearest mirror: $NEAREST_TIKA_SERVER_URL" \
-	&& curl -sSL "$NEAREST_TIKA_SERVER_URL" -o /tika-server-${TIKA_VERSION}.jar \
-	&& apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update
+
+FROM apt_base as fetch_fonts
+
+RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y curl xfonts-utils fonts-freefont-ttf fonts-liberation ttf-mscorefonts-installer wget cabextract
+
+FROM apt_base as runtime_deps
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-11-jre-headless gdal-bin tesseract-ocr \
+        tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
+
+FROM runtime_deps as fetch_tika
+
+ARG TIKA_VERSION
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg curl jq \
+    && curl -sSL https://www.apache.org/dist/tika/KEYS | gpg --import \
+    && curl -sSL https://www.apache.org/dist/tika/tika-server-${TIKA_VERSION}.jar.asc -o /tika-server-${TIKA_VERSION}.jar.asc \
+    && NEAREST_TIKA_SERVER_URL=$(curl --fail -sSL https://www.apache.org/dyn/closer.cgi/tika/tika-server-${TIKA_VERSION}.jar?asjson=1 | jq --raw-output '.preferred + .path_info') \
+    && echo "Nearest mirror: $NEAREST_TIKA_SERVER_URL" \
+    && curl -sSL $NEAREST_TIKA_SERVER_URL -o /tika-server-${TIKA_VERSION}.jar \
+    && gpg --verify /tika-server-${TIKA_VERSION}.jar.asc /tika-server-${TIKA_VERSION}.jar
+
+FROM runtime_deps as runtime
+
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG TIKA_VERSION
+ENV TIKA_VERSION=$TIKA_VERSION
+
+COPY --from=fetch_fonts /usr/share/fonts /usr/share/fonts
+COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 
 EXPOSE 9998
 ENTRYPOINT java -jar /tika-server-${TIKA_VERSION}.jar -h 0.0.0.0
+
+LABEL maintainer david@logicalspark.com

--- a/README.md
+++ b/README.md
@@ -26,21 +26,23 @@ To build the image from scratch, simply invoke:
 
     docker build -t 'docker-tikaserver' github.com/LogicalSpark/docker-tikaserver
    
+If you want to build a particular version, add `--build-arg TIKA_VERSION=x.y` to that command.
+
 You can then use the following command (using the name you allocated in the build command as part of -t option):
 
     docker run -d -p 9998:9998 docker-tikaserver
-    
+
 ## More
 
 For more info on Apache Tika Server, go to the [Apache Tika Server documentation](http://wiki.apache.org/tika/TikaJAXRS).
 
 ## Author
 
-  * David Meikle (<david@logicalspark.com>)
+  * David Meikle (<david@logicalspark.com>) and [contributors](https://github.com/LogicalSpark/docker-tikaserver/graphs/contributors)
 
 ## Licence
 
-   Copyright 2015-2018 David Meikle
+   Copyright 2015-2020 David Meikle
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Actually verify GPG signatures
* Include free fonts, solves #9 and probably #8
* Check for successful downloads to prevent issues like #11 or #22; replaces #23.
* Use a multi-stage build to reduce final image size
* Provide a build arg to conveniently build different versions