### PR TITLE
Add curl to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER david@logicalspark.com
 FROM base as dependencies
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-14-jre-headless gdal-bin tesseract-ocr \
-        tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu
+        tesseract-ocr-eng tesseract-ocr-ita tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-deu curl
 
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y xfonts-utils fonts-freefont-ttf fonts-liberation ttf-mscorefonts-installer wget cabextract
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 \
     && gpg --verify /tika-server-${TIKA_VERSION}.jar.asc /tika-server-${TIKA_VERSION}.jar
 
 FROM dependencies as runtime
-RUN apt-get -y install curl && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install gnupg2 \
     && gpg --verify /tika-server-${TIKA_VERSION}.jar.asc /tika-server-${TIKA_VERSION}.jar
 
 FROM dependencies as runtime
-RUN apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -y install curl && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ENV TIKA_VERSION=$TIKA_VERSION
 COPY --from=fetch_tika /tika-server-${TIKA_VERSION}.jar /tika-server-${TIKA_VERSION}.jar
 


### PR DESCRIPTION
Hi @dameikle ,

Thank you for building and maintaining this image, it's been a pleasure to work with.

We've recently struggled a bit with an upgrade we did.
It pulled the new version of the Dockerfile introduced in https://github.com/LogicalSpark/docker-tikaserver/commit/be18783c99a47c41ec07687264e2f3f19a780d55 .
While a great commit to separate dependencies install from runtime and help make the image small, one side effect of this change was that `curl` got removed from the image.

While not directly useful for the tikaserver per se, `curl` was an useful tool to have on the image to develop Kuvernetes liveness & readiness probes:
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

We want to make sure that the image is able to convert a document, so every 60s, we try to send it a minimal document to convert. `wget` is available on the container, so you could argue we could just use `wget` equivalents of our `curl` calls. However, the syntax to upload a file with `wget` is [a pain to get right](https://superuser.com/questions/86043/linux-command-line-tool-for-uploading-files-over-http-as-multipart-form-data) .
Also, the whole [TikaServer documentation](https://cwiki.apache.org/confluence/display/TIKA/TikaServer#TikaServer-TikaResource) gives examples with `curl`, and those aren't trivial to convert to `wget`.

So this PR adds `curl` back to the runtime image.

Adding `curl` adds a couple of seconds of build time and only increases the image by 3MB (0.44%).

```
$ docker images
REPOSITORY                       TAG                       IMAGE ID            CREATED              SIZE
test-tikaserver                  with-curl                 c828c7fbe7a3        4 seconds ago        691MB
test-tikaserver                  without-curl              b19f961a08b6        About a minute ago   688MB
```

Those small drawbacks would not only allow us to upgrade, but also I believe be convenient in order to quickly debug an issue from the container itself (e.g. when the docker container isn't publicly exposed, but you can SSH on it).